### PR TITLE
Fix the slugs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "arbalest"
-version = "0.1.0" # don't forget to update documentation link on bump
+version = "0.1.1" # don't forget to update documentation link on bump
 authors = ["Anthony Ramine <n.oxyde@gmail.com>", "The Rust Project Developers"]
 description = "Like Arc<T> but where weak references don't forbid mutable access"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/nox/arbalest"
-documentation = "https://docs.rs/arbalest/0.1.0/"
+documentation = "https://docs.rs/arbalest/0.1.1/"
 readme = "README.md"
-categories = ["Concurrency", "Data structures"]
+categories = ["concurrency", "data-structures"]
 keywords = ["arc", "atomic", "thread"]
 exclude = ["/bors.toml", "/.travis.yml"]
 


### PR DESCRIPTION
Because Cargo just emits a warning *after* the publishing, saying he just
ignored the invalid slugs…